### PR TITLE
Fixed showing 404 on user details page

### DIFF
--- a/web/src/views/ocserv_user/OcservUserDetail.vue
+++ b/web/src/views/ocserv_user/OcservUserDetail.vue
@@ -18,10 +18,12 @@ import {
     formatDateWithRelative,
     trafficTypesTransformer
 } from '@/utils/convertors';
+import { useConfigStore } from '@/stores/config';
 
 const props = defineProps<{ uid: string }>();
 
 const { t } = useI18n();
+const configStore = useConfigStore();
 const result = ref<ModelsOcservUser>({
     created_at: '',
     group: '',
@@ -223,7 +225,10 @@ onMounted(() => {
                         </div>
 
                         <!-- Telegram linked accounts -->
-                        <TelegramLinkedAccounts v-if="uid" :uid="uid" />
+                        <TelegramLinkedAccounts
+                            v-if="configStore.telegramBotEnabled && props.uid"
+                            :uid="props.uid"
+                        />
 
                         <!-- Config section -->
                         <div class="bg-surface shadow rounded-lg p-4">


### PR DESCRIPTION
Fixed showing 404 page instead of user details if telegram bot feature is not enabled