### PR TITLE
Fix traffic accounting, activation resets, Telegram RX+TX packages, and cert user group config

### DIFF
--- a/scripts/migrate-ocserv-user-configs.sh
+++ b/scripts/migrate-ocserv-user-configs.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# ==============================================================
+# Script: migrate-ocserv-user-configs.sh
+# Description:
+#   One-time, idempotent migration for existing installations that
+#   may have empty per-user ocserv config files under /etc/ocserv/users.
+#
+#   Empty per-user config files block config-per-group inheritance.
+#   This script replaces empty per-user files with symlinks to the
+#   corresponding group config file.
+#
+#   Non-empty custom per-user config files are preserved.
+#
+# Optional environment:
+#   OCSERV_CONFIG_DIR - ocserv config root, default: /etc/ocserv
+# ==============================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT_DIR}" || exit 1
+
+# shellcheck source=/dev/null
+source ./scripts/lib.sh
+
+if [[ -f "${ROOT_DIR}/.env" ]]; then
+  set -o allexport
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/.env"
+  set +o allexport
+fi
+
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_DB="${POSTGRES_DB:-ocserv}"
+POSTGRES_USER="${POSTGRES_USER:-ocserv}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-}"
+
+OCSERV_CONFIG_DIR="${OCSERV_CONFIG_DIR:-/etc/ocserv}"
+OCSERV_USERS_DIR="${OCSERV_CONFIG_DIR}/users"
+OCSERV_GROUPS_DIR="${OCSERV_CONFIG_DIR}/groups"
+
+if ! command -v psql >/dev/null 2>&1; then
+  die "psql not found. Install PostgreSQL client tools before running this migration."
+fi
+
+if [[ ! -d "${OCSERV_GROUPS_DIR}" ]]; then
+  warn "Ocserv groups directory not found: ${OCSERV_GROUPS_DIR}; skipping user config migration."
+  exit 0
+fi
+
+mkdir -p "${OCSERV_USERS_DIR}"
+
+log "Migrating ocserv per-user config files"
+log "Database: ${POSTGRES_DB} @ ${POSTGRES_HOST}:${POSTGRES_PORT}"
+log "Ocserv config directory: ${OCSERV_CONFIG_DIR}"
+
+migrated=0
+kept=0
+skipped=0
+
+while IFS=$'\t' read -r username group; do
+  if [[ -z "${username}" || -z "${group}" ]]; then
+    continue
+  fi
+
+  if [[ "${username}" == */* || "${group}" == */* ]]; then
+    warn "Skipping unsafe username/group: ${username} -> ${group}"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  group_file="${OCSERV_GROUPS_DIR}/${group}"
+  user_file="${OCSERV_USERS_DIR}/${username}"
+
+  if [[ ! -f "${group_file}" ]]; then
+    warn "Skipping ${username}: missing group file ${group_file}"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [[ -d "${user_file}" && ! -L "${user_file}" ]]; then
+    warn "Keeping ${username}: ${user_file} is a directory"
+    kept=$((kept + 1))
+    continue
+  fi
+
+  if [[ -e "${user_file}" && ! -L "${user_file}" && -s "${user_file}" ]]; then
+    log "Keeping ${username}: non-empty custom user config"
+    kept=$((kept + 1))
+    continue
+  fi
+
+  rm -f "${user_file}"
+  ln -s "${group_file}" "${user_file}"
+
+  log "${username} -> ${group}"
+  migrated=$((migrated + 1))
+done < <(
+  PGPASSWORD="${POSTGRES_PASSWORD}" psql \
+    -h "${POSTGRES_HOST}" \
+    -p "${POSTGRES_PORT}" \
+    -U "${POSTGRES_USER}" \
+    -d "${POSTGRES_DB}" \
+    -AtF $'\t' \
+    -c "SELECT username, \"group\"
+        FROM ocserv_users
+        WHERE \"group\" IS NOT NULL
+          AND \"group\" <> ''
+          AND \"group\" <> 'defaults'
+          AND \"group\" <> '*';"
+)
+
+ok "Ocserv user config migration complete: migrated=${migrated}, kept=${kept}, skipped=${skipped}"
+
+if command -v occtl >/dev/null 2>&1; then
+  if occtl reload; then
+    ok "ocserv configuration reloaded"
+  else
+    warn "occtl reload failed; ocserv may need to be reloaded manually"
+  fi
+else
+  warn "occtl not found; ocserv may need to be reloaded manually"
+fi

--- a/scripts/systemd/backend.sh
+++ b/scripts/systemd/backend.sh
@@ -137,6 +137,10 @@ log "Ensured telegram receipts directory: $RECEIPTS_DIR"
 # -----------------------
 "${BIN_DIR}"/api migrate || exit
 
+# -----------------------
+# Filesystem Migration
+# -----------------------
+./scripts/migrate-ocserv-user-configs.sh
 
 # -----------------------
 # Create systemd units

--- a/services/api/docs/docs.go
+++ b/services/api/docs/docs.go
@@ -4657,6 +4657,8 @@ const docTemplate = `{
         "ocserv_user.SyncOcpasswdRequest": {
             "type": "object",
             "required": [
+                "traffic_size",
+                "traffic_type",
                 "users"
             ],
             "properties": {

--- a/services/api/docs/swagger.json
+++ b/services/api/docs/swagger.json
@@ -4650,6 +4650,8 @@
         "ocserv_user.SyncOcpasswdRequest": {
             "type": "object",
             "required": [
+                "traffic_size",
+                "traffic_type",
                 "users"
             ],
             "properties": {

--- a/services/api/docs/swagger.yaml
+++ b/services/api/docs/swagger.yaml
@@ -925,6 +925,8 @@ definitions:
           $ref: '#/definitions/user.Ocpasswd'
         type: array
     required:
+    - traffic_size
+    - traffic_type
     - users
     type: object
   ocserv_user.UpdateOcservUserData:

--- a/services/api/internal/migrations/011.go
+++ b/services/api/internal/migrations/011.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/mmtaee/ocserv-dashboard/common/pkg/logger"
+	"gorm.io/gorm"
+)
+
+var Migration011 = &gormigrate.Migration{
+	ID: "011_add_ocserv_user_usage_reset_at",
+
+	Migrate: func(tx *gorm.DB) error {
+		if err := tx.Exec(`
+			ALTER TABLE ocserv_users
+			ADD COLUMN IF NOT EXISTS usage_reset_at TIMESTAMPTZ NULL;
+		`).Error; err != nil {
+			return err
+		}
+
+		logger.Info("migration 011 (ocserv_users.usage_reset_at) complete successfully")
+		return nil
+	},
+
+	Rollback: func(tx *gorm.DB) error {
+		return tx.Exec(`
+			ALTER TABLE ocserv_users
+			DROP COLUMN IF EXISTS usage_reset_at;
+		`).Error
+	},
+}

--- a/services/api/internal/repository/ocserv_user.go
+++ b/services/api/internal/repository/ocserv_user.go
@@ -218,11 +218,9 @@ func (o *OcservUserRepository) Create(ctx context.Context, ocservUser *models.Oc
 		return nil, err
 	}
 
-	if ocservUser.Config != nil {
-		go func() {
-			_, _ = o.commonOcservOcctlRepo.ReloadConfigs()
-		}()
-	}
+	go func() {
+		_, _ = o.commonOcservOcctlRepo.ReloadConfigs()
+	}()
 	o.applyCertificateStatus(ocservUser)
 	return ocservUser, err
 }
@@ -263,12 +261,9 @@ func (o *OcservUserRepository) Update(ctx context.Context, ocservUser *models.Oc
 		return nil, err
 	}
 
-	if ocservUser.Config != nil {
-		go func() {
-			_, _ = o.commonOcservOcctlRepo.ReloadConfigs()
-		}()
-	}
-
+	go func() {
+		_, _ = o.commonOcservOcctlRepo.ReloadConfigs()
+	}()
 	return ocservUser, nil
 }
 

--- a/services/api/internal/repository/ocserv_user.go
+++ b/services/api/internal/repository/ocserv_user.go
@@ -508,16 +508,24 @@ func (o *OcservUserRepository) RestoreExpired(ctx context.Context, uid string, e
 			return err
 		}
 
+		terminateOutput, err := o.commonOcservOcctlRepo.TerminateUser(u.Username)
+		if err != nil && !isNoActiveOcctlUserError(terminateOutput, err) {
+			return fmt.Errorf("failed to terminate ocserv user %q: %s: %w", u.Username, strings.TrimSpace(terminateOutput), err)
+		}
+
 		unlockOutput, err := o.commonOcservUserRepo.UnLock(u.Username)
 		if err != nil && !isAlreadyUnlockedOcpasswdError(unlockOutput, err) {
 			return fmt.Errorf("failed to unlock ocserv user %q: %s: %w", u.Username, strings.TrimSpace(unlockOutput), err)
 		}
+
+		now := time.Now()
 
 		if err := tx.
 			Model(&u).
 			Updates(map[string]interface{}{
 				"expire_at":      expireAt,
 				"deactivated_at": nil,
+				"usage_reset_at": &now,
 				"is_locked":      false,
 				"rx":             0,
 				"tx":             0,
@@ -577,6 +585,15 @@ func isAlreadyUnlockedOcpasswdError(output string, err error) bool {
 		strings.Contains(text, "not disabled") ||
 		strings.Contains(text, "already unlocked") ||
 		strings.Contains(text, "already enabled")
+}
+
+func isNoActiveOcctlUserError(output string, err error) bool {
+	text := strings.ToLower(strings.TrimSpace(output + " " + err.Error()))
+
+	return strings.Contains(text, "could not terminate user") ||
+		strings.Contains(text, "could not disconnect user") ||
+		strings.Contains(text, "not found") ||
+		strings.Contains(text, "no such user")
 }
 
 func (o *OcservUserRepository) UserSessionLogs(

--- a/services/api/internal/services/ocserv_user/controller.go
+++ b/services/api/internal/services/ocserv_user/controller.go
@@ -574,9 +574,26 @@ func (ctl *Controller) SyncToDB(c echo.Context) error {
 		return ctl.request.BadRequest(c, err)
 	}
 
-	expireAt, err := time.Parse("2006-01-02", *data.ExpireAt)
-	if err != nil {
-		expireAt, _ = time.Parse("2006-01-02", time.Now().AddDate(0, 0, 30).Format("2006-01-02"))
+	expireAt := time.Now().AddDate(0, 0, 30)
+	if data.ExpireAt != nil && *data.ExpireAt != "" {
+		parsedExpireAt, err := time.Parse("2006-01-02", *data.ExpireAt)
+		if err == nil {
+			expireAt = parsedExpireAt
+		}
+	}
+
+	if data.TrafficType == nil {
+		return ctl.request.BadRequest(c, errors.New("traffic_type is required"))
+	}
+
+	if data.TrafficSize == nil {
+		return ctl.request.BadRequest(c, errors.New("traffic_size is required"))
+	}
+
+	trafficType := *data.TrafficType
+	trafficSize := *data.TrafficSize
+	if trafficType == models.Free {
+		trafficSize = 0
 	}
 
 	var users []models.OcservUser
@@ -595,8 +612,8 @@ func (ctl *Controller) SyncToDB(c echo.Context) error {
 				Group:       u.Group,
 				Owner:       owner,
 				ExpireAt:    &expireAt,
-				TrafficSize: *data.TrafficSize,
-				TrafficType: *data.TrafficType,
+				TrafficSize: trafficSize,
+				TrafficType: trafficType,
 				Config:      data.Config,
 			}
 

--- a/services/api/internal/services/ocserv_user/types.go
+++ b/services/api/internal/services/ocserv_user/types.go
@@ -38,8 +38,8 @@ type OcservUsersResponse struct {
 type SyncOcpasswdRequest struct {
 	Users       []user.Ocpasswd          `json:"users" validate:"required"`
 	ExpireAt    *string                  `json:"expire_at" validate:"omitempty" example:"2025-12-31"`
-	TrafficType *string                  `json:"traffic_type" validate:"oneof=Free MonthlyTransmit MonthlyReceive MonthlyRxTx TotallyTransmit TotallyReceive TotallyRxTx"`
-	TrafficSize *int64                   `json:"traffic_size" validate:"gte=0" example:"10737418240"` // 10 GiB
+	TrafficType *string                  `json:"traffic_type" validate:"required,oneof=Free MonthlyTransmit MonthlyReceive MonthlyRxTx TotallyTransmit TotallyReceive TotallyRxTx"`
+	TrafficSize *int64                   `json:"traffic_size" validate:"required,gte=0" example:"10737418240"` // 10 GiB
 	Description *string                  `json:"description" validate:"omitempty,max=1024" example:"User for testing VPN access"`
 	Config      *models.OcservUserConfig `json:"config" validate:"omitempty"`
 }

--- a/services/api/internal/services/system/controller.go
+++ b/services/api/internal/services/system/controller.go
@@ -52,7 +52,22 @@ func New() *Controller {
 func (ctl *Controller) DashboardRelease(c echo.Context) error {
 	current := os.Getenv("CURRENT_RELEASE")
 
-	resp, err := http.Get("https://api.github.com/repos/mmtaee/ocserv-dashboard/releases/latest")
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	req, err := http.NewRequestWithContext(
+		c.Request().Context(),
+		http.MethodGet,
+		"https://api.github.com/repos/mmtaee/ocserv-dashboard/releases/latest",
+		nil,
+	)
+	if err != nil {
+		return ctl.request.BadRequest(c, errors.New("failed to create latest release request"))
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "ocserv-dashboard")
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return ctl.request.BadRequest(c, errors.New("failed to fetch latest release"))
 	}
@@ -63,6 +78,10 @@ func (ctl *Controller) DashboardRelease(c echo.Context) error {
 			logger.Error("error on close io.ReadCloser: %v", err)
 		}
 	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return ctl.request.BadRequest(c, errors.New("failed to fetch latest release"))
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/services/api/internal/services/system/routes.go
+++ b/services/api/internal/services/system/routes.go
@@ -7,19 +7,7 @@ import (
 
 func Routes(e *echo.Group) {
 	ctl := New()
-	e.GET("/system/init", ctl.SystemInit)
-	e.POST("/system/setup", ctl.SetupSystem)
-	e.POST(
-		"/system/user/reset-password",
-		ctl.ResetAdminPassword,
-		middlewares.RateLimitMiddleware(1, "m", 2),
-	)
-	e.POST(
-		"/system/users/login",
-		ctl.Login,
-		middlewares.RateLimitMiddleware(2, "m", 3),
-	)
-	
+
 	// =========================
 	// Public system routes
 	// =========================
@@ -28,8 +16,11 @@ func Routes(e *echo.Group) {
 	system.GET("/release", ctl.DashboardRelease)
 	system.GET("/init", ctl.SystemInit)
 	system.POST("/setup", ctl.SetupSystem)
-
-	// Auth (rate limited login)
+	system.POST(
+		"/user/reset-password",
+		ctl.ResetAdminPassword,
+		middlewares.RateLimitMiddleware(1, "m", 2),
+	)
 	system.POST(
 		"/users/login",
 		ctl.Login,

--- a/services/api/internal/services/telegram/types.go
+++ b/services/api/internal/services/telegram/types.go
@@ -30,7 +30,7 @@ type PatchSettingsData struct {
 	CardNumber          *string `json:"card_number" validate:"omitempty,max=64"`
 	CardHolder          *string `json:"card_holder" validate:"omitempty,max=128"`
 	// SupportUsername must be a Telegram handle without @ (5–32 chars, a–z 0–9 _).
-	SupportUsername     *string `json:"support_username" validate:"omitempty,max=64"`
+	SupportUsername *string `json:"support_username" validate:"omitempty,max=64"`
 }
 
 type TestData struct {
@@ -41,7 +41,7 @@ type CreatePackageData struct {
 	Title         string `json:"title" validate:"required,min=2,max=128"`
 	Days          int    `json:"days" validate:"required,min=1,max=3650"`
 	TrafficSizeGB int    `json:"traffic_size_gb" validate:"min=0,max=100000"`
-	TrafficType   string `json:"traffic_type" validate:"required,oneof=Free MonthlyTransmit MonthlyReceive TotallyTransmit TotallyReceive"`
+	TrafficType   string `json:"traffic_type" validate:"required,oneof=Free MonthlyTransmit MonthlyReceive MonthlyRxTx TotallyTransmit TotallyReceive TotallyRxTx"`
 	PriceText     string `json:"price_text" validate:"omitempty,max=64"`
 	IsActive      bool   `json:"is_active"`
 }
@@ -50,7 +50,7 @@ type PatchPackageData struct {
 	Title         *string `json:"title" validate:"omitempty,min=2,max=128"`
 	Days          *int    `json:"days" validate:"omitempty,min=1,max=3650"`
 	TrafficSizeGB *int    `json:"traffic_size_gb" validate:"omitempty,min=0,max=100000"`
-	TrafficType   *string `json:"traffic_type" validate:"omitempty,oneof=Free MonthlyTransmit MonthlyReceive TotallyTransmit TotallyReceive"`
+	TrafficType   *string `json:"traffic_type" validate:"omitempty,oneof=Free MonthlyTransmit MonthlyReceive MonthlyRxTx TotallyTransmit TotallyReceive TotallyRxTx"`
 	PriceText     *string `json:"price_text" validate:"omitempty,max=64"`
 	IsActive      *bool   `json:"is_active"`
 }

--- a/services/api/pkg/bootstrap/migrate.go
+++ b/services/api/pkg/bootstrap/migrate.go
@@ -19,6 +19,7 @@ var Migrations = []*gormigrate.Migration{
 	migrations.Migration008,
 	migrations.Migration009,
 	migrations.Migration010,
+	migrations.Migration011,
 }
 
 func Migrate() {

--- a/services/api/pkg/crypto/password_test.go
+++ b/services/api/pkg/crypto/password_test.go
@@ -1,22 +1,24 @@
 package crypto_test
 
 import (
-	"github.com/mmtaee/ocserv-dashboard/api/pkg/crypto"
-	"github.com/stretchr/testify/assert"
-	"os"
 	"testing"
+
+	"github.com/mmtaee/ocserv-dashboard/api/pkg/crypto"
+	"github.com/mmtaee/ocserv-dashboard/common/pkg/config"
+	"github.com/stretchr/testify/assert"
 )
 
-func setup() *crypto.CustomPassword {
-	err := os.Setenv("JWT_SECRET", "my-secret-key")
-	if err != nil {
-		return nil
-	}
+func setup(t *testing.T) *crypto.CustomPassword {
+	t.Helper()
+
+	t.Setenv("SECRET_KEY", "my-secret-key")
+	config.Init(false, "", 0)
+
 	return crypto.NewCustomPassword()
 }
 
 func TestCreatePasswordDefaultSaltLength(t *testing.T) {
-	cp := setup()
+	cp := setup(t)
 	result := cp.CreatePassword("mypassword")
 
 	assert.NotEmpty(t, result.Salt)
@@ -25,14 +27,14 @@ func TestCreatePasswordDefaultSaltLength(t *testing.T) {
 }
 
 func TestCreatePasswordCustomSaltLength(t *testing.T) {
-	cp := setup()
+	cp := setup(t)
 	result := cp.CreatePassword("mypassword", 10)
 
 	assert.Equal(t, 10, len(result.Salt))
 }
 
 func TestCheckPasswordCorrectPassword(t *testing.T) {
-	cp := setup()
+	cp := setup(t)
 	data := cp.CreatePassword("securepass")
 
 	match := cp.CheckPassword("securepass", data.Hash, data.Salt)
@@ -40,7 +42,7 @@ func TestCheckPasswordCorrectPassword(t *testing.T) {
 }
 
 func TestCheckPasswordWrongPassword(t *testing.T) {
-	cp := setup()
+	cp := setup(t)
 	data := cp.CreatePassword("securepass")
 
 	match := cp.CheckPassword("wrongpass", data.Hash, data.Salt)
@@ -48,7 +50,7 @@ func TestCheckPasswordWrongPassword(t *testing.T) {
 }
 
 func TestCheckPasswordWrongSalt(t *testing.T) {
-	cp := setup()
+	cp := setup(t)
 	data := cp.CreatePassword("securepass")
 
 	match := cp.CheckPassword("securepass", data.Hash, "badSalt")

--- a/services/api/pkg/crypto/token_test.go
+++ b/services/api/pkg/crypto/token_test.go
@@ -1,18 +1,21 @@
 package crypto
 
 import (
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/stretchr/testify/assert"
-	"os"
 	"testing"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/mmtaee/ocserv-dashboard/common/pkg/config"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateAccessToken(t *testing.T) {
 	userID := "12345"
 	adminUsername := "admin"
 	secret := "my-secret-key"
-	err := os.Setenv("JWT_SECRET", secret)
+	t.Setenv("JWT_SECRET", secret)
+	config.Init(false, "", 0)
+
 	expire := time.Now().Add(time.Hour).Unix()
 
 	tokenString, err := GenerateAccessToken(userID, adminUsername, expire, true)

--- a/services/common/models/ocserv_user.go
+++ b/services/common/models/ocserv_user.go
@@ -73,6 +73,7 @@ type OcservUser struct {
 	UpdatedAt            time.Time                    `json:"updated_at" gorm:"autoUpdateTime" validate:"omitempty"`
 	ExpireAt             *time.Time                   `json:"expire_at" gorm:"type:date" validate:"omitempty"`
 	DeactivatedAt        *time.Time                   `json:"deactivated_at" gorm:"type:date" validate:"omitempty"`
+	UsageResetAt         *time.Time                   `json:"-" gorm:"type:timestamptz" validate:"omitempty"`
 	TrafficType          string                       `json:"traffic_type" gorm:"type:varchar(32);not null;default:1" enums:"Free,MonthlyTransmit,MonthlyReceive,MonthlyRxTx,TotallyTransmit,TotallyReceive,TotallyRxTx" validate:"required"`
 	TrafficSize          int64                        `json:"traffic_size" gorm:"not null" validate:"required"` // in bytes
 	Rx                   int                          `json:"rx" gorm:"not null;default:0" validate:"required"` // Receive in bytes

--- a/services/common/ocserv/occtl/occtl.go
+++ b/services/common/ocserv/occtl/occtl.go
@@ -94,15 +94,12 @@ func (o *OcservOcctl) DisconnectSession(id string) (string, error) {
 	return string(out), nil
 }
 
-// TerminateUser Disconnect user and invalidate session cookies.
+// TerminateUser disconnects a user and invalidates session cookies.
 // Executes: occtl terminate user <username>
 func (o *OcservOcctl) TerminateUser(username string) (string, error) {
 	cmd := exec.Command(occtlExec, "terminate", "user", username)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
+	return string(out), err
 }
 
 // TerminateSession Disconnect ID and invalidate session cookies.

--- a/services/common/ocserv/user/user.go
+++ b/services/common/ocserv/user/user.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mmtaee/ocserv-dashboard/common/pkg/utils"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 )
 
@@ -22,6 +21,7 @@ type OcservUserManagement interface {
 }
 
 type OcservUserConfigManagement interface {
+	SyncConfig(username, group string, config *models.OcservUserConfig) error
 	CreateConfig(username string, config *models.OcservUserConfig) error
 	DeleteConfig(username string) error
 }
@@ -68,24 +68,9 @@ func (u *OcservUser) Create(group, username, password string, config *models.Ocs
 		return err
 	}
 
-	if config != nil {
-		filename := filepath.Join(utils.ConfigUserBaseDir, username)
-
-		var file *os.File
-
-		// Open file with create, truncate, write-only flags and permission 0640
-		file, err = os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0640)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-
-		err = utils.ConfigWriter(file, utils.ToMap(config))
-		if err != nil {
-			return err
-		}
+	if err = u.SyncConfig(username, group, config); err != nil {
+		return err
 	}
-
 	return nil
 }
 
@@ -125,37 +110,104 @@ func (u *OcservUser) Delete(username string) (string, error) {
 	if err := u.RevokeCertificate(username); err != nil {
 		return "", err
 	}
-
 	output, err := utils.RunOcpasswd("-d", "-c", utils.OcpasswdPath, username)
 	if err != nil {
 		return "", err
 	}
+
+	if err := u.DeleteConfig(username); err != nil {
+		return "", err
+	}
+
 	return output, nil
+
+}
+
+func (u *OcservUser) SyncConfig(username, group string, config *models.OcservUserConfig) error {
+	filename := utils.UserConfigFilePathCreator(username)
+
+	if err := os.MkdirAll(utils.ConfigUserBaseDir, 0750); err != nil {
+		return err
+	}
+
+	if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if hasConfigValues(config) {
+		return u.CreateConfig(username, config)
+	}
+
+	group = strings.TrimSpace(group)
+	if group == "" || group == "defaults" {
+		return nil
+	}
+
+	groupConfig := utils.GroupConfigFilePathCreator(group)
+	if _, err := os.Stat(groupConfig); err != nil {
+		return err
+	}
+
+	return os.Symlink(groupConfig, filename)
+}
+
+func hasConfigValues(config *models.OcservUserConfig) bool {
+	if config == nil {
+		return false
+	}
+
+	for _, value := range utils.ToMap(config) {
+		switch v := value.(type) {
+		case nil:
+			continue
+		case bool:
+			if v {
+				return true
+			}
+		case string:
+			if strings.TrimSpace(v) != "" {
+				return true
+			}
+		case []interface{}:
+			if len(v) > 0 {
+				return true
+			}
+		default:
+			return true
+		}
+	}
+
+	return false
 }
 
 // CreateConfig writes a per-user configuration file for the given username.
 // The configuration is serialized from OcservUserConfig using pkg.ConfigWriter.
 // The file is created with permission 0640 and stored in the user config directory.
 func (u *OcservUser) CreateConfig(username string, config *models.OcservUserConfig) error {
+	if !hasConfigValues(config) {
+		return nil
+	}
+
 	filename := utils.UserConfigFilePathCreator(username)
-	// Open file with create, truncate, write-only flags and permission 0640
+
+	if err := os.MkdirAll(utils.ConfigUserBaseDir, 0750); err != nil {
+		return err
+	}
+
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0640)
 	if err != nil {
 		return err
 	}
-	err = utils.ConfigWriter(file, utils.ToMap(config))
-	if err != nil {
-		return err
-	}
-	return nil
+	defer file.Close()
+
+	return utils.ConfigWriter(file, utils.ToMap(config))
 }
 
 // DeleteConfig removes the per-user configuration file for the given username.
-// The config file path is derived from UserConfigFilePathCreator. If the file does
-// not exist or cannot be removed, an error is returned.
+// The config file path is derived from UserConfigFilePathCreator.
 func (u *OcservUser) DeleteConfig(username string) error {
 	filename := utils.UserConfigFilePathCreator(username)
-	if err := os.Remove(filename); err != nil {
+	if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil

--- a/services/common/pkg/utils/utils.go
+++ b/services/common/pkg/utils/utils.go
@@ -98,7 +98,7 @@ func ConfigWriter(file *os.File, config map[string]interface{}) error {
 			continue
 		} else {
 			if _, err := file.WriteString(fmt.Sprintf("%s=%s\n", k, formatConfigValue(v))); err != nil {
-			return fmt.Errorf("failed to write to file: %w", err)
+				return fmt.Errorf("failed to write to file: %w", err)
 			}
 		}
 	}
@@ -150,7 +150,7 @@ func formatConfigValue(v interface{}) string {
 
 // GetUsersByGroup parses the ocpasswd file and returns usernames
 // belonging to the given group. It ignores comments, empty lines,
-// and malformed entries. Assumes group is stored as the third field
+// and malformed entries. The ocpasswd group is stored as the second field
 // in colon-separated records. Returns an error if scanning fails.
 func GetUsersByGroup(groupName string) ([]string, error) {
 	file, err := os.Open(OcpasswdPath)
@@ -174,8 +174,10 @@ func GetUsersByGroup(groupName string) ([]string, error) {
 		}
 
 		username := parts[0]
-		group := parts[2]
-
+		group := parts[1]
+		if group == "*" {
+			group = "defaults"
+		}
 		if group == groupName {
 			users = append(users, username)
 		}
@@ -282,7 +284,7 @@ func GetOcservVersion() string {
 		logger.Error("Command error: %v", err)
 		return ""
 	}
-	
+
 	// Combine stdout and stderr for pattern matching
 	fullOutput := out.String() + stderr.String()
 

--- a/services/log_stream/internal/readers/docker.go
+++ b/services/log_stream/internal/readers/docker.go
@@ -21,7 +21,7 @@ func DockerStreamLogs(ctx context.Context, containerName string, streamChan chan
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     true,
-		Tail:       "100",
+		Tail:       "0",
 	}
 
 	logReader, err := cli.ContainerLogs(ctx, containerName, options)
@@ -37,6 +37,7 @@ func DockerStreamLogs(ctx context.Context, containerName string, streamChan chan
 	}()
 
 	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 
 		select {

--- a/services/log_stream/internal/readers/systemd.go
+++ b/services/log_stream/internal/readers/systemd.go
@@ -3,11 +3,20 @@ package readers
 import (
 	"bufio"
 	"context"
+	"encoding/json"
+	"fmt"
 	"os/exec"
+	"strings"
 )
 
+type journalEntry struct {
+	Message string `json:"MESSAGE"`
+	PID     string `json:"_PID"`
+}
+
 func SystemdStreamLogs(ctx context.Context, serviceName string, streamChan chan<- string) error {
-	cmd := exec.Command("journalctl", "-n", "100", "-fu", serviceName, "--output=cat")
+	cmd := exec.CommandContext(ctx, "journalctl", "-n", "0", "-fu", serviceName, "--output=json")
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
@@ -18,12 +27,29 @@ func SystemdStreamLogs(ctx context.Context, serviceName string, streamChan chan<
 	defer cmd.Wait()
 
 	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
 	for scanner.Scan() {
+		var entry journalEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+
+		message := strings.TrimSpace(entry.Message)
+		if message == "" {
+			continue
+		}
+
+		if entry.PID != "" && !strings.HasPrefix(message, "ocserv[") {
+			message = fmt.Sprintf("ocserv[%s]: %s", entry.PID, message)
+		}
+
 		select {
 		case <-ctx.Done():
 			return nil
-		case streamChan <- scanner.Text():
+		case streamChan <- message:
 		}
 	}
+
 	return scanner.Err()
 }

--- a/services/log_stream/internal/stats/service.go
+++ b/services/log_stream/internal/stats/service.go
@@ -20,23 +20,31 @@ import (
 )
 
 type StatService struct {
-	ctx             context.Context
-	stream          <-chan string
-	ocservUserRepo  user.OcservUserInterface
-	ocservOcctlRepo occtl.OcservOcctlInterface
-	occtlDockerRepo occtlDocker.OcservOcctlUsersDocker
-	dockerMode      bool
-	sessionStats    map[string]UserStats
+	ctx                 context.Context
+	stream              <-chan string
+	ocservUserRepo      user.OcservUserInterface
+	ocservOcctlRepo     occtl.OcservOcctlInterface
+	occtlDockerRepo     occtlDocker.OcservOcctlUsersDocker
+	dockerMode          bool
+	sessionStats        map[string]UserStats
+	pendingMainSessions map[string][]pendingMainSession
+	workerSessionIDs    map[string]string
+}
+
+type pendingMainSession struct {
+	Endpoint  string
+	CreatedAt time.Time
 }
 
 func NewStatService(ctx context.Context, stream chan string, dockerMode bool) *StatService {
 	s := &StatService{
-		ctx:          ctx,
-		stream:       stream,
-		dockerMode:   dockerMode,
-		sessionStats: make(map[string]UserStats),
+		ctx:                 ctx,
+		stream:              stream,
+		dockerMode:          dockerMode,
+		sessionStats:        make(map[string]UserStats),
+		pendingMainSessions: make(map[string][]pendingMainSession),
+		workerSessionIDs:    make(map[string]string),
 	}
-
 	if dockerMode {
 		s.occtlDockerRepo = occtlDocker.NewOcservOcctlDocker()
 	} else {
@@ -72,6 +80,8 @@ func (s *StatService) CalculateUserStats() {
 			if !strings.Contains(cleanLine, "worker[") && !strings.Contains(cleanLine, "main[") {
 				continue
 			}
+
+			s.trackSessionIdentity(cleanLine)
 
 			if strings.Contains(cleanLine, "sent periodic stats") {
 				stats, err := s.getPeriodicStat(cleanLine)
@@ -173,21 +183,25 @@ func (s *StatService) getPeriodicStat(cleanLine string) (*UserStats, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	tx, err := strconv.Atoi(matchRxTx[4])
 	if err != nil {
 		return nil, err
 	}
 
+	ip := normalizeSessionIP(matchRxTx[2])
+
 	return &UserStats{
-		Username: matchRxTx[1],
-		IP:       normalizeSessionIP(matchRxTx[2]),
-		RX:       rx,
-		TX:       tx,
+		Username:  matchRxTx[1],
+		IP:        ip,
+		SessionID: s.workerSessionID(matchRxTx[1], ip, cleanLine),
+		RX:        rx,
+		TX:        tx,
 	}, nil
 }
 
 func (s *StatService) getDisconnectStat(cleanLine string) (*UserStats, error) {
-	reTxRx := regexp.MustCompile(`main\[([^\]]+)\]:\s*(\S+).*rx:\s*(\d+),\s*tx:\s*(\d+)`)
+	reTxRx := regexp.MustCompile(`main\[([^\]]+)\]:(\S+)\s+user disconnected.*rx:\s*(\d+),\s*tx:\s*(\d+)`)
 	matchRxTx := reTxRx.FindStringSubmatch(cleanLine)
 	if len(matchRxTx) == 5 {
 		rx, err := strconv.Atoi(matchRxTx[3])
@@ -201,33 +215,35 @@ func (s *StatService) getDisconnectStat(cleanLine string) (*UserStats, error) {
 		}
 
 		return &UserStats{
-			Username: matchRxTx[1],
-			IP:       normalizeSessionIP(matchRxTx[2]),
-			RX:       rx,
-			TX:       tx,
+			Username:  matchRxTx[1],
+			IP:        normalizeSessionIP(matchRxTx[2]),
+			SessionID: matchRxTx[2],
+			RX:        rx,
+			TX:        tx,
 		}, nil
 	}
 
-	reTxRx = regexp.MustCompile(`main\[([^\]]+)\].*rx:\s*(\d+),\s*tx:\s*(\d+)`)
-	matchRxTx = reTxRx.FindStringSubmatch(cleanLine)
-	if len(matchRxTx) != 4 {
+	fallbackRe := regexp.MustCompile(`main\[([^\]]+)\].*rx:\s*(\d+),\s*tx:\s*(\d+)`)
+	fallbackMatch := fallbackRe.FindStringSubmatch(cleanLine)
+	if len(fallbackMatch) != 4 {
 		return nil, nil
 	}
 
-	rx, err := strconv.Atoi(matchRxTx[2])
+	rx, err := strconv.Atoi(fallbackMatch[2])
 	if err != nil {
 		return nil, err
 	}
 
-	tx, err := strconv.Atoi(matchRxTx[3])
+	tx, err := strconv.Atoi(fallbackMatch[3])
 	if err != nil {
 		return nil, err
 	}
 
 	return &UserStats{
-		Username: matchRxTx[1],
-		RX:       rx,
-		TX:       tx,
+		Username:  fallbackMatch[1],
+		SessionID: processIDFromLine(cleanLine),
+		RX:        rx,
+		TX:        tx,
 	}, nil
 }
 
@@ -240,31 +256,147 @@ func normalizeSessionIP(endpoint string) string {
 	return endpoint
 }
 
+func processIDFromLine(line string) string {
+	re := regexp.MustCompile(`(?:^|\s)ocserv\[(\d+)\]:`)
+	match := re.FindStringSubmatch(line)
+	if len(match) != 2 {
+		return ""
+	}
+
+	return match[1]
+}
+
+func usernameIPKey(username, ip string) string {
+	return fmt.Sprintf("%s|%s", username, ip)
+}
+
+func workerIdentityKey(username, ip, pid string) string {
+	return fmt.Sprintf("%s|%s|pid:%s", username, ip, pid)
+}
+
 func sessionStatsKey(stats *UserStats) string {
-	return fmt.Sprintf("%s|%s", stats.Username, stats.IP)
+	if stats.SessionID != "" {
+		return fmt.Sprintf("%s|%s|%s", stats.Username, stats.IP, stats.SessionID)
+	}
+
+	return fmt.Sprintf("%s|%s|unknown", stats.Username, stats.IP)
+}
+
+func (s *StatService) trackSessionIdentity(line string) {
+	mainRe := regexp.MustCompile(`main\[([^\]]+)\]:(\S+)\s+new user session`)
+	if match := mainRe.FindStringSubmatch(line); len(match) == 3 {
+		username := match[1]
+		endpoint := match[2]
+		ip := normalizeSessionIP(endpoint)
+		key := usernameIPKey(username, ip)
+
+		s.pendingMainSessions[key] = append(s.pendingMainSessions[key], pendingMainSession{
+			Endpoint:  endpoint,
+			CreatedAt: time.Now(),
+		})
+
+		return
+	}
+
+	workerRe := regexp.MustCompile(`worker\[([^\]]+)\]:\s*(\S+)`)
+	match := workerRe.FindStringSubmatch(line)
+	if len(match) != 3 {
+		return
+	}
+
+	pid := processIDFromLine(line)
+	if pid == "" {
+		return
+	}
+
+	username := match[1]
+	ip := normalizeSessionIP(match[2])
+	workerKey := workerIdentityKey(username, ip, pid)
+	if _, ok := s.workerSessionIDs[workerKey]; ok {
+		return
+	}
+
+	pendingKey := usernameIPKey(username, ip)
+	pending := s.pendingMainSessions[pendingKey]
+	if len(pending) == 0 {
+		return
+	}
+
+	now := time.Now()
+	filtered := pending[:0]
+	for _, item := range pending {
+		if now.Sub(item.CreatedAt) <= 2*time.Minute {
+			filtered = append(filtered, item)
+		}
+	}
+
+	if len(filtered) == 0 {
+		delete(s.pendingMainSessions, pendingKey)
+		return
+	}
+
+	s.workerSessionIDs[workerKey] = filtered[0].Endpoint
+
+	if len(filtered) == 1 {
+		delete(s.pendingMainSessions, pendingKey)
+		return
+	}
+
+	s.pendingMainSessions[pendingKey] = filtered[1:]
+}
+
+func (s *StatService) workerSessionID(username, ip, line string) string {
+	pid := processIDFromLine(line)
+	if pid == "" {
+		return ""
+	}
+
+	workerKey := workerIdentityKey(username, ip, pid)
+	if sessionID, ok := s.workerSessionIDs[workerKey]; ok {
+		return sessionID
+	}
+
+	return "pid:" + pid
+}
+
+func (s *StatService) hasSessionStatsForUserIP(username, ip string) bool {
+	prefix := fmt.Sprintf("%s|%s|", username, ip)
+
+	for key := range s.sessionStats {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (s *StatService) saveRxTxDelta(ctx context.Context, stats *UserStats, final bool) error {
 	key := sessionStatsKey(stats)
 	lastStats, found := s.sessionStats[key]
 
+	if final && !found && s.hasSessionStatsForUserIP(stats.Username, stats.IP) {
+		logger.Warn("Skipping unmatched final RxTx stats for user=%s ip=%s session=%s RX=%d TX=%d", stats.Username, stats.IP, stats.SessionID, stats.RX, stats.TX)
+		return nil
+	}
+
 	deltaRx := stats.RX
 	deltaTx := stats.TX
+
 	if found {
 		deltaRx = stats.RX - lastStats.RX
 		deltaTx = stats.TX - lastStats.TX
 	}
 
-	// A lower value means ocserv started a new session for the same user/IP.
+	// A lower value means ocserv started a new session for the same stats key.
 	// In that case, the current stat is the first value of the new session.
 	if deltaRx < 0 || deltaTx < 0 {
 		deltaRx = stats.RX
 		deltaTx = stats.TX
 	}
 
-	// Keep the final value too.
-	// ocserv may emit a duplicate periodic stat after the disconnect line.
-	// If we delete the memory on disconnect, that duplicate gets counted again.
+	// Keep the latest value, including final disconnect values.
+	// This prevents duplicate final/periodic lines from being counted again.
 	s.sessionStats[key] = *stats
 
 	if deltaRx == 0 && deltaTx == 0 {
@@ -272,16 +404,16 @@ func (s *StatService) saveRxTxDelta(ctx context.Context, stats *UserStats, final
 	}
 
 	return s.saveRxTx(ctx, &UserStats{
-		Username: stats.Username,
-		IP:       stats.IP,
-		RX:       deltaRx,
-		TX:       deltaTx,
+		Username:  stats.Username,
+		IP:        stats.IP,
+		SessionID: stats.SessionID,
+		RX:        deltaRx,
+		TX:        deltaTx,
 	})
-
 }
 
 func (s *StatService) saveRxTx(ctx context.Context, u *UserStats) error {
-	logger.Info("saveRxTx called for user=%s RX=%d TX=%d", u.Username, u.RX, u.TX)
+	logger.Info("saveRxTx called for user=%s ip=%s session=%s RX=%d TX=%d", u.Username, u.IP, u.SessionID, u.RX, u.TX)
 
 	db := database.GetConnection()
 	db = db.WithContext(ctx)

--- a/services/log_stream/internal/stats/service.go
+++ b/services/log_stream/internal/stats/service.go
@@ -187,24 +187,45 @@ func (s *StatService) getPeriodicStat(cleanLine string) (*UserStats, error) {
 }
 
 func (s *StatService) getDisconnectStat(cleanLine string) (*UserStats, error) {
-	reTxRx := regexp.MustCompile(`main\[([^\]]+)\].*rx:\s*(\d+),\s*tx:\s*(\d+)`)
+	reTxRx := regexp.MustCompile(`main\[([^\]]+)\]:\s*(\S+).*rx:\s*(\d+),\s*tx:\s*(\d+)`)
 	matchRxTx := reTxRx.FindStringSubmatch(cleanLine)
-	if len(matchRxTx) <= 4 {
+	if len(matchRxTx) == 5 {
+		rx, err := strconv.Atoi(matchRxTx[3])
+		if err != nil {
+			return nil, err
+		}
+
+		tx, err := strconv.Atoi(matchRxTx[4])
+		if err != nil {
+			return nil, err
+		}
+
+		return &UserStats{
+			Username: matchRxTx[1],
+			IP:       normalizeSessionIP(matchRxTx[2]),
+			RX:       rx,
+			TX:       tx,
+		}, nil
+	}
+
+	reTxRx = regexp.MustCompile(`main\[([^\]]+)\].*rx:\s*(\d+),\s*tx:\s*(\d+)`)
+	matchRxTx = reTxRx.FindStringSubmatch(cleanLine)
+	if len(matchRxTx) != 4 {
 		return nil, nil
 	}
 
-	rx, err := strconv.Atoi(matchRxTx[3])
+	rx, err := strconv.Atoi(matchRxTx[2])
 	if err != nil {
 		return nil, err
 	}
-	tx, err := strconv.Atoi(matchRxTx[4])
+
+	tx, err := strconv.Atoi(matchRxTx[3])
 	if err != nil {
 		return nil, err
 	}
 
 	return &UserStats{
 		Username: matchRxTx[1],
-		IP:       normalizeSessionIP(matchRxTx[2]),
 		RX:       rx,
 		TX:       tx,
 	}, nil
@@ -250,17 +271,13 @@ func (s *StatService) saveRxTxDelta(ctx context.Context, stats *UserStats, final
 		return nil
 	}
 
-	var err error
-	if final {
-		err = s.saveRxTx(ctx, &UserStats{
-			Username: stats.Username,
-			IP:       stats.IP,
-			RX:       deltaRx,
-			TX:       deltaTx,
-		})
-	}
+	return s.saveRxTx(ctx, &UserStats{
+		Username: stats.Username,
+		IP:       stats.IP,
+		RX:       deltaRx,
+		TX:       deltaTx,
+	})
 
-	return err
 }
 
 func (s *StatService) saveRxTx(ctx context.Context, u *UserStats) error {

--- a/services/log_stream/internal/stats/service.go
+++ b/services/log_stream/internal/stats/service.go
@@ -311,7 +311,7 @@ func (s *StatService) saveRxTx(ctx context.Context, u *UserStats) error {
 
 	trafficSizeBytes := ocUser.TrafficSize
 
-	totalMonthStats, err := s.getCurrentMonthTotals(db, ocUser.ID)
+	totalMonthStats, err := s.getCurrentMonthTotals(db, ocUser.ID, ocUser.UsageResetAt)
 	if err != nil {
 		logger.Error("Error getting current month stats: %v", err)
 		return err
@@ -394,15 +394,20 @@ func (s *StatService) saveSessionLog(ctx context.Context, log *models.OcservUser
 	return nil
 }
 
-func (s *StatService) getCurrentMonthTotals(db *gorm.DB, userID uint) (Totals, error) {
+func (s *StatService) getCurrentMonthTotals(db *gorm.DB, userID uint, usageResetAt *time.Time) (Totals, error) {
 	now := time.Now()
 	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
 	endOfMonth := startOfMonth.AddDate(0, 1, 0)
 
+	startAt := startOfMonth
+	if usageResetAt != nil && usageResetAt.After(startAt) {
+		startAt = *usageResetAt
+	}
+
 	var result Totals
 	err := db.Model(&models.OcservUserTrafficStatistics{}).
 		Select("SUM(rx) as total_rx, SUM(tx) as total_tx").
-		Where("oc_user_id = ? AND created_at >= ? AND created_at < ?", userID, startOfMonth, endOfMonth).
+		Where("oc_user_id = ? AND created_at >= ? AND created_at < ?", userID, startAt, endOfMonth).
 		Scan(&result).Error
 
 	return result, err

--- a/services/log_stream/internal/stats/types.go
+++ b/services/log_stream/internal/stats/types.go
@@ -1,10 +1,11 @@
 package stats
 
 type UserStats struct {
-	Username string
-	IP       string
-	RX       int
-	TX       int
+	Username  string
+	IP        string
+	SessionID string
+	RX        int
+	TX        int
 }
 
 type Totals struct {

--- a/services/user_expiry/internal/service/service.go
+++ b/services/user_expiry/internal/service/service.go
@@ -274,9 +274,12 @@ func (c *CornService) ActiveMonthlyUsers(ctx context.Context, db *gorm.DB) {
 			defer wg.Done()
 			defer func() { <-sem }()
 
+			now := time.Now()
+
 			if err2 := db.Model(&u).Updates(map[string]interface{}{
 				"rx":             0,
 				"tx":             0,
+				"usage_reset_at": &now,
 				"deactivated_at": nil,
 				"is_locked":      false,
 			}).Error; err2 != nil {

--- a/web/src/api/models/ocserv-user-sync-ocpasswd-request.ts
+++ b/web/src/api/models/ocserv-user-sync-ocpasswd-request.ts
@@ -49,13 +49,13 @@ export interface OcservUserSyncOcpasswdRequest {
      * @type {number}
      * @memberof OcservUserSyncOcpasswdRequest
      */
-    'traffic_size'?: number;
+    'traffic_size': number;
     /**
      * 
      * @type {string}
      * @memberof OcservUserSyncOcpasswdRequest
      */
-    'traffic_type'?: OcservUserSyncOcpasswdRequestTrafficTypeEnum;
+    'traffic_type': OcservUserSyncOcpasswdRequestTrafficTypeEnum;
     /**
      * 
      * @type {Array<UserOcpasswd>}

--- a/web/src/components/customer/SummaryResult.vue
+++ b/web/src/components/customer/SummaryResult.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { CustomerSummaryResponse } from '@/api';
-import { bytesToGB, bytesToTrafficSize, formatDate, trafficTypesTransformer } from '@/utils/convertors';
+import { bytesToGB, bytesToTrafficSize, formatDate, numberToFixer, trafficTypesTransformer } from '@/utils/convertors';
 import UiChildCard from '@/components/shared/UiChildCard.vue';
 import { useI18n } from 'vue-i18n';
 
@@ -138,16 +138,15 @@ const { t } = useI18n();
                                 <span class="ms-1">{{ formatDate(result.usage.date_end) }}</span>
                             </v-col>
                         </v-row>
-
                         <v-row align="center" justify="start">
                             <v-col cols="12" md="6">
                                 <span class="font-medium text-gray-600 text-capitalize"> RX: </span>
-                                <span class="ms-1">{{ bytesToGB(result.usage.bandwidths.rx) }} GB</span>
+                                <span class="ms-1">{{ numberToFixer(result.usage.bandwidths.rx, 6) }} GB</span>
                             </v-col>
 
                             <v-col cols="12" md="6">
                                 <span class="font-medium text-gray-600 text-capitalize"> TX: </span>
-                                <span class="ms-1">{{ bytesToGB(result.usage.bandwidths.tx) }} GB</span>
+                                <span class="ms-1">{{ numberToFixer(result.usage.bandwidths.tx, 6) }} GB</span>
                             </v-col>
                         </v-row>
                     </div>

--- a/web/src/components/ocserv_user/dialogs/ActivateDialog.vue
+++ b/web/src/components/ocserv_user/dialogs/ActivateDialog.vue
@@ -18,7 +18,7 @@ const emits = defineEmits(['activateUser', 'close']);
 
 const { t } = useI18n();
 
-const expireAt = ref(null);
+const expireAt = ref<Date | string | null>(null);
 const showDateMenu = ref(false);
 </script>
 

--- a/web/src/components/ocserv_user/list/Actions.vue
+++ b/web/src/components/ocserv_user/list/Actions.vue
@@ -10,7 +10,7 @@ import ActivateDialog from '@/components/ocserv_user/dialogs/ActivateDialog.vue'
 import SessionLogsDialog from '@/components/ocserv_user/dialogs/SessionLogsDialog.vue';
 import DisconnectDialog from '@/components/ocserv_user/dialogs/DisconnectDialog.vue';
 import { ref } from 'vue';
-import { formatDate } from 'date-fns';
+import { formatDate } from '@/utils/convertors';
 
 defineProps<{ item: ModelsOcservUser }>();
 
@@ -147,12 +147,8 @@ const unlock = (uid: string) => {
     });
 };
 
-const activateUser = (expireAt: string | null) => {
-    if (expireAt == null) {
-        expireAt = '';
-    }
-
-    const formattedExpireAt = formatDate(expireAt, '');
+const activateUser = (expireAt: Date | string | null) => {
+    const formattedExpireAt = formatDate(expireAt);
 
     api.ocservUsersUidActivatePost({
         ...getAuthorization(),
@@ -161,7 +157,7 @@ const activateUser = (expireAt: string | null) => {
             expire_at: formattedExpireAt || undefined
         }
     }).then(() => {
-        emit('actions', 'activateUser', activateUserUID.value, {
+        emit('actions', 'activate', activateUserUID.value, {
             formattedExpireAt: formattedExpireAt
         });
         cancelActivateUser();

--- a/web/src/plugins/axios.ts
+++ b/web/src/plugins/axios.ts
@@ -55,9 +55,6 @@ api.interceptors.response.use(
                 window.location.href = '/login';
             }
             if (response.status === 400) {
-                if (response.data.hasOwnProperty('error') && response.data['error'] == 'record not found') {
-                    window.location.href = '/not_found';
-                }
                 const snackbar = useSnackbarStore();
                 let errorList = response.data.error;
                 if (Array.isArray(errorList)) {

--- a/web/src/plugins/axios.ts
+++ b/web/src/plugins/axios.ts
@@ -55,6 +55,13 @@ api.interceptors.response.use(
                 window.location.href = '/login';
             }
             if (response.status === 400) {
+                if (
+                    !window.location.pathname.startsWith('/summary') &&
+                    response.data.hasOwnProperty('error') &&
+                    response.data['error'] == 'record not found'
+                ) {
+                    window.location.href = '/not_found';
+                }
                 const snackbar = useSnackbarStore();
                 let errorList = response.data.error;
                 if (Array.isArray(errorList)) {

--- a/web/src/views/telegram/Packages.vue
+++ b/web/src/views/telegram/Packages.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { ModelsOcservUserTrafficTypeEnum } from '@/api';
 import { TelegramAPI, type TelegramPackage } from '@/api/telegram';
 import { useSnackbarStore } from '@/stores/snackbar';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
+import { trafficTypesTransformer } from '@/utils/convertors';
 
 const { t } = useI18n();
 const snackbar = useSnackbarStore();
@@ -15,11 +17,34 @@ const editing = ref<TelegramPackage>(emptyPackage());
 const isNew = ref(true);
 
 const trafficTypes = [
-    { value: 'TotallyTransmit', title: 'TotallyTransmit' },
-    { value: 'TotallyReceive', title: 'TotallyReceive' },
-    { value: 'MonthlyTransmit', title: 'MonthlyTransmit' },
-    { value: 'MonthlyReceive', title: 'MonthlyReceive' },
-    { value: 'Free', title: 'Free' }
+    {
+        value: ModelsOcservUserTrafficTypeEnum.TOTALLY_TRANSMIT,
+        title: trafficTypesTransformer(ModelsOcservUserTrafficTypeEnum.TOTALLY_TRANSMIT)
+    },
+    {
+        value: ModelsOcservUserTrafficTypeEnum.TOTALLY_RECEIVE,
+        title: trafficTypesTransformer(ModelsOcservUserTrafficTypeEnum.TOTALLY_RECEIVE)
+    },
+    {
+        value: ModelsOcservUserTrafficTypeEnum.TOTALLY_RX_TX,
+        title: trafficTypesTransformer(ModelsOcservUserTrafficTypeEnum.TOTALLY_RX_TX)
+    },
+    {
+        value: ModelsOcservUserTrafficTypeEnum.MONTHLY_TRANSMIT,
+        title: trafficTypesTransformer(ModelsOcservUserTrafficTypeEnum.MONTHLY_TRANSMIT)
+    },
+    {
+        value: ModelsOcservUserTrafficTypeEnum.MONTHLY_RECEIVE,
+        title: trafficTypesTransformer(ModelsOcservUserTrafficTypeEnum.MONTHLY_RECEIVE)
+    },
+    {
+        value: ModelsOcservUserTrafficTypeEnum.MONTHLY_RX_TX,
+        title: trafficTypesTransformer(ModelsOcservUserTrafficTypeEnum.MONTHLY_RX_TX)
+    },
+    {
+        value: ModelsOcservUserTrafficTypeEnum.FREE,
+        title: trafficTypesTransformer(ModelsOcservUserTrafficTypeEnum.FREE)
+    }
 ];
 
 function emptyPackage(): TelegramPackage {
@@ -28,11 +53,15 @@ function emptyPackage(): TelegramPackage {
         title: '',
         days: 30,
         traffic_size_gb: 30,
-        traffic_type: 'TotallyTransmit',
+        traffic_type: ModelsOcservUserTrafficTypeEnum.TOTALLY_TRANSMIT,
         price_text: '',
         is_active: true
     };
 }
+
+const formatTrafficType = (trafficType: string): string => {
+    return trafficTypesTransformer(trafficType as ModelsOcservUserTrafficTypeEnum);
+};
 
 const load = async () => {
     loading.value = true;
@@ -135,7 +164,7 @@ onMounted(load);
                                 <td>{{ pkg.title }}</td>
                                 <td>{{ pkg.days }}</td>
                                 <td>{{ pkg.traffic_size_gb }}</td>
-                                <td>{{ pkg.traffic_type }}</td>
+                                <td>{{ formatTrafficType(pkg.traffic_type) }}</td>
                                 <td>{{ pkg.price_text || '—' }}</td>
                                 <td>
                                     <v-chip :color="pkg.is_active ? 'success' : 'grey'" size="small" variant="flat">


### PR DESCRIPTION
## Summary

This PR fixes several important issues around customer traffic display, ocpasswd sync validation, Telegram package traffic modes, certificate-authenticated users picking up group configuration, traffic accounting, and user activation/reset behavior.

## Changes

### Fixed customer monthly bandwidth display

The customer summary page was applying `bytesToGB()` to monthly usage values that were already returned by the backend in GiB.

This caused monthly RX/TX usage to be displayed as extremely small values, often effectively `0 GB`.

The frontend now formats those already-converted values directly instead of converting them a second time.

### Fixed ocpasswd sync request validation

The ocpasswd sync endpoint accepted nullable request fields but dereferenced them directly.

Missing `traffic_type`, `traffic_size`, or `expire_at` could cause a nil pointer panic on malformed or partial requests.

This PR now validates required traffic fields properly and handles optional expiry safely.

Invalid sync requests now return a normal `400 Bad Request` instead of risking a panic.

### Cleaned up duplicated system route registrations

Some public system routes were registered more than once.

This PR keeps the same public routes and behavior, but registers them through a single `/system` route group.

### Added timeout-safe dashboard release check

The dashboard release endpoint used `http.Get()` without a timeout.

This PR changes it to use an HTTP client with timeout and request context, preventing the endpoint from hanging indefinitely if GitHub or the network is slow/unresponsive.

### Added RX+TX traffic types to Telegram packages

Telegram packages can now use the same RX+TX traffic modes supported by the main dashboard:

* `MonthlyRxTx`
* `TotallyRxTx`

This allows Telegram-created packages to use combined RX + TX traffic limits.

### Fixed certificate users not picking up group configuration

Certificate-authenticated users could fail to pick up the latest group settings such as speed limits and max-same-clients.

The issue was caused by empty per-user config files under `/etc/ocserv/users/<username>` blocking the effective group config.

This PR changes user config syncing so users without custom per-user config get a symlink from their per-user config path to their group config file:

```text
/etc/ocserv/users/<username> -> /etc/ocserv/groups/<group>
```

This lets certificate-authenticated users follow the latest group config without requiring certificate regeneration.

Users with real non-empty custom per-user config files are preserved.

User deletion now also removes the related per-user config file/symlink to avoid stale config files after delete/recreate.

### Fixed traffic accounting from ocserv stats

The log stream service was not persisting traffic usage correctly.

Periodic stats were parsed but not saved, and disconnected-session stats had a parsing/indexing issue that prevented RX/TX from being stored.

This caused users to remain at `0 GB` usage in the panel, which also prevented traffic limits from being enforced.

This PR fixes periodic and disconnect stat handling so `ocserv_user_traffic_statistics` and user RX/TX counters are updated correctly.

### Fixed traffic overcounting for overlapping sessions

The log stream service tracked ocserv session counters by username and IP address only.

That was not enough when the same user had multiple simultaneous or overlapping sessions from the same IP address.

In that case, independent ocserv worker counters could be mixed together, causing cumulative session values to be saved repeatedly as new traffic deltas.

This could make a user reach their traffic limit much faster than they actually consumed.

This PR now preserves session identity from ocserv logs and uses a stronger accounting key that includes the session endpoint or ocserv worker PID when available.

This prevents overlapping/reconnecting sessions for the same user/IP from corrupting RX/TX delta calculations.

### Stopped log stream from replaying old logs on restart

The systemd log reader used `journalctl -n 100 -fu`, which replayed the last 100 ocserv log lines every time `log_stream` started.

After periodic stats persistence was fixed, replaying old periodic stat lines could cause recent traffic to be counted again after a service restart.

This PR changes the systemd reader to start from new log lines only and preserves journal metadata needed for session tracking.

The Docker log reader was also adjusted to avoid replaying old log lines on startup.

### Fixed deactivated user activation dialog

The activation dialog for deactivated users could fail when selecting a new expiry date.

The frontend used the wrong date formatter and emitted the wrong action name after activation.

This caused console errors such as `RangeError: Invalid time value` and prevented the activate button in the popup from working correctly.

The dialog now formats dates safely and updates the user row correctly after successful activation.

### Fixed reactivated user traffic reset behavior

Reactivating a locked/deactivated user reset `ocserv_users.rx` and `ocserv_users.tx`, but old rows in `ocserv_user_traffic_statistics` could still affect quota calculations.

This was especially problematic for monthly traffic modes, because monthly quota enforcement is based on the statistics table.

This PR adds an internal `usage_reset_at` timestamp to `ocserv_users`.

When a user is reactivated, the backend now:

* terminates any active session for that user before resetting usage
* resets `rx` and `tx` to zero
* stores the reset boundary in `usage_reset_at`
* keeps old traffic statistics rows for historical reporting

Monthly quota checks now count traffic only after the later of the current month start or `usage_reset_at`.

This preserves historical traffic data while ensuring reactivated users receive a clean new quota period.

## Upgrade note

This PR includes a one-time filesystem migration for existing installations that may already have empty per-user config files under `/etc/ocserv/users`.

The migration is handled by:

```bash
./scripts/migrate-ocserv-user-configs.sh
```
Already-connected users may need to reconnect before all group settings apply.

This PR also adds a database migration for `ocserv_users.usage_reset_at`.

After deployment, `log_stream` should be restarted so the new log reader and session accounting logic are used immediately.

## Testing

Tested with:

```bash
cd services/api
go test ./...
```

```bash
cd services/log_stream
go test ./...
```

```bash
cd services/user_expiry
go test ./...
```

```bash
cd web
yarn typecheck
yarn build
```

Also tested on live systemd deployments:

* `/api/system/init` returns `200 OK`
* `/api/system/release` returns quickly and correctly
* malformed ocpasswd sync request returns `400 Bad Request`
* valid ocpasswd sync request still succeeds
* API service remains active after malformed sync request
* Telegram packages can use RX+TX traffic types
* certificate-authenticated users can have `/etc/ocserv/users/<username>` symlinked to the correct group config
* periodic and disconnect traffic stats are persisted again
* user RX/TX counters increase after VPN traffic is consumed
* traffic limits are applied again after accounting updates
* overlapping/reconnecting sessions no longer share the same username/IP-only accounting key
* `log_stream` no longer replays old ocserv log lines on restart
* deactivated users can be activated again from the frontend dialog
* reactivated users get a fresh quota period without deleting historical traffic statistics
* monthly quota enforcement ignores pre-reactivation traffic by respecting `usage_reset_at`
* total quota modes reset from `ocserv_users.rx/tx` while preserving historical statistics
* frontend production build succeeds
